### PR TITLE
Update Socat COnfiguration

### DIFF
--- a/docker-compose.tailscale-router.yaml
+++ b/docker-compose.tailscale-router.yaml
@@ -45,7 +45,7 @@ services:
       depends_on:
         - web
       post_start:
-       - command: ["sh", "-c", "socat TCP-LISTEN:8080,reuseaddr,fork TCP:${DDEV_SITENAME}-web:${DDEV_ROUTER_HTTP_PORT} &"]
-
+       - command: ["sh", "-c", "socat TCP-LISTEN:8080,reuseaddr,fork TCP:web:${DDEV_ROUTER_HTTP_PORT} >> /var/log/ddev.log 2>&1 &"]
+       
 volumes:
   tailscale-router-state:


### PR DESCRIPTION
## The Issue

- Fixes the tailscale routing to a non-existent container

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

The Socat was listening to ${DDEV_SITE_NAME}-web instead of web for the container

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/atj4me/ddev-tailscale-router/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```


## Release/Deployment Notes

Update to new release
