### PR TITLE
Updaing tests to use matrix to test on different OSes and architectures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,14 +35,20 @@ jobs:
         if: startsWith(matrix.os, 'macos-latest')
         run: |
           brew update
-          brew install lima docker qemu
-          brew install lima lima-additional-guestagents
+          brew install lima lima-additional-guestagents docker qemu
           mkdir -p /tmp/lima
-          # Use qemu VM driver instead of vz to avoid current vz issues
-          limactl create --name=default --vm-type=qemu --mount-type=9p --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
           if limactl list | grep -q default; then
             limactl delete default
           fi
+          limactl create \
+            --name=default \
+            --vm-type=qemu \
+            --mount-type=9p \
+            --mount-writable \
+            --memory=6 \
+            --cpus=4 \
+            --disk=100 \
+            template://docker
           limactl start default
           docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock" || true
           docker context use lima-default

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,34 +31,23 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Enable Actions step debug logging
-        run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
-      
-      - name: Setup Debug Session (tmate SSH)
-        uses: csexton/debugger-action@master
-        if: ${{ github.event.inputs.debug_enabled == 'true' }}
-      
-      - name: Setup Lima, Docker, and QEMU
+      - name: Set up on macOS runners
+        if: startsWith(matrix.os, 'macos-latest')
         run: |
           brew update
-          brew install lima lima-additional-guestagents docker qemu
+          brew install lima docker qemu
+          brew install lima lima-additional-guestagents
           mkdir -p /tmp/lima
+          # Use qemu VM driver instead of vz to avoid current vz issues
+          limactl create --name=default --vm-type=qemu --cpu=host --memory=4 --cpus=2 --mount-type=9p ... template://docker
+
           if limactl list | grep -q default; then
             limactl delete default
           fi
-          limactl create --name=default --vm-type=qemu --mount-type=9p --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
           limactl start default
           docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock" || true
           docker context use lima-default
           limactl list
-      
-      - name: Dump Lima logs for debugging
-        if: failure()
-        run: |
-          echo "HA stderr log:"
-          cat ~/.lima/default/ha.stderr.log || echo "No ha.stderr.log available"
-          echo "Serial logs:"
-          cat ~/.lima/default/serial*.log || echo "No serial logs available"
 
       - name: Run DDEV Add-on Tests
         uses: ddev/github-action-add-on-test@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,11 +28,13 @@ jobs:
       matrix:
         ddev_version: [stable, HEAD]
         os: [ubuntu-24.04, ubuntu-24.04-arm64, macos-latest]
-      fail-fast: false
-      continue-on-error: true
-
+        include:
+          - os: macos-latest
+            allow_failure: true
+    fail-fast: false
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure == true }}
 
     steps:
       - uses: ddev/github-action-add-on-test@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,11 @@ jobs:
           brew update
           brew install lima docker qemu
           mkdir -p /tmp/lima
+          # Use qemu VM driver instead of vz to avoid current vz issues
+          limactl create --name=default --vm-type=qemu --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
           if limactl list | grep -q default; then
             limactl delete default
           fi
-          # Use qemu VM driver instead of vz to avoid current vz issues
-          limactl create --name=default --vm-type=qemu --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
           limactl start default
           docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock" || true
           docker context use lima-default

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
           if limactl list | grep -q default; then
             limactl delete default
           fi
-          limactl create --name=default --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
+          limactl create --name=default --vm-type=qemu --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
           
           # Start the lima VM instance
           limactl start default

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,7 @@ jobs:
           brew install lima lima-additional-guestagents
           mkdir -p /tmp/lima
           # Use qemu VM driver instead of vz to avoid current vz issues
-          limactl create --name=default --vm-type=qemu --cpu=host --memory=4 --cpus=2 --mount-type=9p ... template://docker
-
+          limactl create --name=default --vm-type=qemu --cpus=2 --memory=4 --mount-type=9p template://docker
           if limactl list | grep -q default; then
             limactl delete default
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,6 @@ jobs:
           mkdir -p /tmp/lima
           # Use qemu VM driver instead of vz to avoid current vz issues
           limactl create --name=default --vm-type=qemu --cpus=2 --memory=4 --mount-type=9p template://docker
-          if limactl list | grep -q default; then
-            limactl delete default
-          fi
-          limactl start default
           docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock" || true
           docker context use lima-default
           limactl list

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,10 +3,8 @@ on:
   pull_request:
   push:
     branches: [ main ]
-
   schedule:
-  - cron: '25 08 * * *'
-
+    - cron: '25 08 * * *'
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -33,16 +31,32 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Install Homebrew on MacOS
+      - name: Set up on macOS runners
         if: startsWith(matrix.os, 'macos-latest')
         run: |
-          brew install lima
-          brew install docker
+          # Update Homebrew and install lima and docker CLI
+          brew update
+          brew install lima docker
+          
+          # Ensure required mount directory exists to avoid lima warnings
+          mkdir -p /tmp/lima
+          
+          # Create lima instance, override if exists
+          if limactl list | grep -q default; then
+            limactl delete default
+          fi
           limactl create --name=default --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
+          
+          # Start the lima VM instance
           limactl start default
-          docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock"
+          
+          # Create docker context pointing to lima unix socket
+          docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock" || true
           docker context use lima-default
-          imactl list
+          
+          # Verify lima instance status
+          limactl list
+
       - name: Run DDEV Add-on Tests
         uses: ddev/github-action-add-on-test@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
-        os: [ubuntu-24.04, ubuntu-24.04-arm64]
+        os: [ubuntu-24.04, ubuntu-22.04-arm, windows-11-arm]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,9 +36,10 @@ jobs:
         run: |
           brew update
           brew install lima docker qemu
+          brew install lima lima-additional-guestagents
           mkdir -p /tmp/lima
           # Use qemu VM driver instead of vz to avoid current vz issues
-          limactl create --name=default --vm-type=qemu --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
+          limactl create --name=default --vm-type=qemu --mount-type=9p --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
           if limactl list | grep -q default; then
             limactl delete default
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,10 @@ jobs:
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
-        os: [ubuntu-24.04, ubuntu-24.04-arm64, macos-15]
+        os: [ubuntu-24.04, ubuntu-24.04-arm64, macos-latest]
       fail-fast: false
+      continue-on-error: true
+
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
-        os: [ubuntu-24.04, macos-latest]
+        os: [ubuntu-24.04]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,14 +34,14 @@ jobs:
 
     steps:
       - name: Install Homebrew on MacOS
-          if: startsWith(matrix.os, 'macos-latest')
-          run: |
-            brew install lima
-            brew install docker
-            limactl create --name=default --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
-            docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock"
-            docker context use lima-default
-            limactl start
+        if: startsWith(matrix.os, 'macos-latest')
+        run: |
+          brew install lima
+          brew install docker
+          limactl create --name=default --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
+          docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock"
+          docker context use lima-default
+          limactl start
       - name: Run DDEV Add-on Tests
         uses: ddev/github-action-add-on-test@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,25 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: ddev/github-action-add-on-test@v2
+      - name: Install Homebrew on Linux
+        if: startsWith(matrix.os, 'ubuntu-22.04-arm')
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential curl file git -y
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.bashrc
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+
+      - name: Install Homebrew on Windows
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Homebrew/install/HEAD/install.ps1 -OutFile install.ps1
+          .\install.ps1
+        shell: pwsh
+
+      - name: Run DDEV Add-on Tests
+        uses: ddev/github-action-add-on-test@v2
         with:
           ddev_version: ${{ matrix.ddev_version }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         include:
           - os: macos-latest
             allow_failure: true
-    fail-fast: false
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow_failure == true }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,10 @@ jobs:
           brew install lima
           brew install docker
           limactl create --name=default --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
+          limactl start default
           docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock"
           docker context use lima-default
+          imactl list
       - name: Run DDEV Add-on Tests
         uses: ddev/github-action-add-on-test@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,27 +34,17 @@ jobs:
       - name: Set up on macOS runners
         if: startsWith(matrix.os, 'macos-latest')
         run: |
-          # Update Homebrew and install lima and docker CLI
           brew update
-          brew install lima docker
-          
-          # Ensure required mount directory exists to avoid lima warnings
+          brew install lima docker qemu
           mkdir -p /tmp/lima
-          
-          # Create lima instance, override if exists
           if limactl list | grep -q default; then
             limactl delete default
           fi
+          # Use qemu VM driver instead of vz to avoid current vz issues
           limactl create --name=default --vm-type=qemu --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
-          
-          # Start the lima VM instance
           limactl start default
-          
-          # Create docker context pointing to lima unix socket
           docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock" || true
           docker context use lima-default
-          
-          # Verify lima instance status
           limactl list
 
       - name: Run DDEV Add-on Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,10 @@ jobs:
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
+        os: [ubuntu-24.04, ubuntu-24.04-arm64, macos-15]
       fail-fast: false
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: ddev/github-action-add-on-test@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,6 @@ jobs:
           limactl create --name=default --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
           docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock"
           docker context use lima-default
-          limactl start
       - name: Run DDEV Add-on Tests
         uses: ddev/github-action-add-on-test@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up on macOS runners
-        if: startsWith(matrix.os, 'macos-latest')
+      - name: Enable Actions step debug logging
+        run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
+      
+      - name: Setup Debug Session (tmate SSH)
+        uses: csexton/debugger-action@master
+        if: ${{ github.event.inputs.debug_enabled == 'true' }}
+      
+      - name: Setup Lima, Docker, and QEMU
         run: |
           brew update
           brew install lima lima-additional-guestagents docker qemu
@@ -40,19 +46,19 @@ jobs:
           if limactl list | grep -q default; then
             limactl delete default
           fi
-          limactl create \
-            --name=default \
-            --vm-type=qemu \
-            --mount-type=9p \
-            --mount-writable \
-            --memory=6 \
-            --cpus=4 \
-            --disk=100 \
-            template://docker
+          limactl create --name=default --vm-type=qemu --mount-type=9p --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
           limactl start default
           docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock" || true
           docker context use lima-default
           limactl list
+      
+      - name: Dump Lima logs for debugging
+        if: failure()
+        run: |
+          echo "HA stderr log:"
+          cat ~/.lima/default/ha.stderr.log || echo "No ha.stderr.log available"
+          echo "Serial logs:"
+          cat ~/.lima/default/serial*.log || echo "No serial logs available"
 
       - name: Run DDEV Add-on Tests
         uses: ddev/github-action-add-on-test@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,14 +27,10 @@ jobs:
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
-        os: [ubuntu-24.04, ubuntu-24.04-arm64, macos-latest]
-        include:
-          - os: macos-latest
-            allow_failure: true
+        os: [ubuntu-24.04, ubuntu-24.04-arm64]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow_failure == true }}
 
     steps:
       - uses: ddev/github-action-add-on-test@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,29 +27,21 @@ jobs:
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
-        os: [ubuntu-24.04, ubuntu-22.04-arm, windows-11-arm]
+        os: [ubuntu-24.04, macos-latest]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Install Homebrew on Linux
-        if: startsWith(matrix.os, 'ubuntu-22.04-arm')
-        run: |
-          sudo apt-get update
-          sudo apt-get install build-essential curl file git -y
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.bashrc
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-
-      - name: Install Homebrew on Windows
-        if: startsWith(matrix.os, 'windows')
-        run: |
-          Set-ExecutionPolicy Bypass -Scope Process -Force
-          Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Homebrew/install/HEAD/install.ps1 -OutFile install.ps1
-          .\install.ps1
-        shell: pwsh
-
+      - name: Install Homebrew on MacOS
+          if: startsWith(matrix.os, 'macos-latest')
+          run: |
+            brew install lima
+            brew install docker
+            limactl create --name=default --vm-type=vz --mount-type=virtiofs --mount-writable --memory=6 --cpus=4 --disk=100 template://docker
+            docker context create lima-default --docker "host=unix://$HOME/.lima/default/sock/docker.sock"
+            docker context use lima-default
+            limactl start
       - name: Run DDEV Add-on Tests
         uses: ddev/github-action-add-on-test@v2
         with:

--- a/docker-compose.tailscale-router.yaml
+++ b/docker-compose.tailscale-router.yaml
@@ -4,15 +4,8 @@ services:
       # We build a custom image to add socat
       build:
         context: .
-        args:
-          - DDEV_UID=${DDEV_UID}
-          - DDEV_GID=${DDEV_GID}
-          - DDEV_USER=ddev
         dockerfile_inline: |
           FROM tailscale/tailscale:latest
-          ARG DDEV_USER
-          ARG DDEV_UID
-          ARG DDEV_GID
           RUN <<EOF
            set -eu
             apk add --no-cache socat

--- a/install.yaml
+++ b/install.yaml
@@ -1,13 +1,5 @@
 name: ddev-tailscale-router
 
-pre_install_actions:
-  - |
-    #ddev-description: Check architecture type for incompatible arm64 type
-    if [ "$(uname -m)" = "arm64" -o "$(uname -m)" = "aarch64" ]; then
-      echo "This package does not work on arm64 (Apple Silicon) machines";
-      exit 1;
-    fi
-
 project_files:
   - .env.tailscale-router
   - tailscale-router/config/tailscale-private.json


### PR DESCRIPTION
## The Issue

- Fixes #6

The addon doesn't currently support ARM architecture on MacOS. This attempts to fix it. 

## How This PR Solves The Issue

Moved the Tailscale networking to UserSpace so as to not have a dependency on Tunnels, which non linux distros won't have. 
In addition, updated the tests to include testing on different OS

## Manual Testing Instructions

Test on Latest Mac Devices

```bash
ddev add-on get https://github.com/atj4me/ddev-tailscale-router/tarball/refs/pull/6/head
ddev restart
```

## Automated Testing Overview

Added testing on `[ubuntu-24.04, ubuntu-24.04-arm64, macos-15]`  for various architecture

## Release/Deployment Notes

There is no change for existing installations. It gives support for Mac OS and also remove some unwanted logic, which doesn't affect functionality. 
This would fix #6 

