### PR TITLE
Add TailScale Logout to automatically logout from the node once exited

### DIFF
--- a/docker-compose.tailscale-router.yaml
+++ b/docker-compose.tailscale-router.yaml
@@ -29,6 +29,8 @@ services:
       - web
     post_start:
       - command: ["sh", "-c", "socat TCP-LISTEN:8080,reuseaddr,fork TCP:web:${DDEV_ROUTER_HTTP_PORT} >> /var/log/ddev.log 2>&1 &"]
+    pre_stop:
+      - command: ["tailscale", "logout"]
 
 volumes:
   tailscale-router-state:

--- a/install.yaml
+++ b/install.yaml
@@ -10,6 +10,11 @@ ddev_version_constraint: '>= v1.24.3'
 
 post_install_actions:
   - |
+    #ddev-description:Setup Tailscale router environment
+    if ! ddev dotenv get .ddev/.env.tailscale-router TS_PRIVACY >/dev/null 2>&1; then
+      ddev dotenv set .ddev/.env.tailscale-router --ts-privacy=private
+    fi
+  - |
     #ddev-description:Setup instructions for Tailscale router
     echo "🚀 ddev-tailscale-router installed successfully!"
     echo "Next steps:"

--- a/install.yaml
+++ b/install.yaml
@@ -11,7 +11,7 @@ ddev_version_constraint: '>= v1.24.3'
 post_install_actions:
   - |
     #ddev-description:Setup Tailscale router environment
-    if ! ddev dotenv get .ddev/.env.tailscale-router TS_PRIVACY >/dev/null 2>&1; then
+    if ! ddev dotenv get .ddev/.env.tailscale-router --ts-privacy >/dev/null 2>&1; then
       ddev dotenv set .ddev/.env.tailscale-router --ts-privacy=private
     fi
   - |


### PR DESCRIPTION
Fixes #12

## The Issue

- Fixes #12

Adds a tailscale logout using container lifecycle hooks

## How This PR Solves The Issue

When tailscale logout runs, it removes the ephemeral node from the account, without waiting on the schedule job which runs in 30 mins to 48 hours

## Manual Testing Instructions

Start the project, wait until the node starts. Then stop the project and observe the status

```bash
ddev add-on get https://github.com/atj4me/ddev-tailscale-router/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```
