### PR TITLE
fix: follow standard docker-compose.yaml for addons, update README.md

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,12 @@
 name: tests
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   push:
     branches: [ main ]
+    paths-ignore:
+      - "**.md"
   schedule:
     - cron: '25 08 * * *'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -3,21 +3,24 @@
 [![last commit](https://img.shields.io/github/last-commit/atj4me/ddev-tailscale-router)](https://github.com/atj4me/ddev-tailscale-router/commits)
 [![release](https://img.shields.io/github/v/release/atj4me/ddev-tailscale-router)](https://github.com/atj4me/ddev-tailscale-router/releases/latest)
 
-# ddev-tailscale-router <!-- omit in toc -->
+# DDEV Tailscale Router <!-- omit in toc -->
 
-- [What is ddev-tailscale-router?](#what-is-ddev-tailscale-router)
+- [Overview](#overview)
 - [Use Cases](#use-cases)
 - [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Advanced Customization](#advanced-customization)
 - [Components of the Repository](#components-of-the-repository)
-- [Getting Started](#getting-started)
-- [Commands](#commands)
 - [Testing](#testing)
 - [Contributing](#contributing)
 - [License](#license)
 
-## What is ddev-tailscale-router?
+## Overview
 
-**ddev-tailscale-router** is a DDEV add-on that provides stable, secure URLs for your local DDEV development sites using [Tailscale](https://tailscale.com/). Unlike temporary sharing solutions, this gives you permanent, human-readable URLs that work across all your Tailscale-connected devices.
+[Tailscale](https://tailscale.com/) is a VPN service that creates a private and secure network between your devices.
+
+This add-on integrates Tailscale into your [DDEV](https://ddev.com) project. Unlike temporary sharing solutions, this gives you permanent, human-readable URLs that work across all your Tailscale-connected devices.
 
 Read the full blog post: [Tailscale for DDEV: Simple and Secure Project Sharing](https://ddev.com/blog/tailscale-router-ddev-addon/)
 
@@ -34,57 +37,28 @@ This add-on is particularly useful for:
 
 Before installing the add-on:
 
-1. **Install Tailscale** on your development machine: [Download Tailscale](https://tailscale.com/download)
-2. **Add a second device** to your Tailscale network (phone, tablet, or another computer)
-3. **Enable HTTPS** in your [Tailscale admin console](hhttps://tailscale.com/kb/1153/enabling-https) by clicking "Enable HTTPS..." (required for TLS certificate generation)
+1. [Install Tailscale](https://tailscale.com/download) on any two devices (computer, phone, or tablet). This is required to generate the auth key.
+2. [Generate an auth key](https://tailscale.com/kb/1085/auth-keys) in your [Keys settings](https://login.tailscale.com/admin/settings/keys) (ephemeral, reusable keys are recommended).
+3. [Enable HTTPS](https://tailscale.com/kb/1153/enabling-https) in your [DNS settings](https://login.tailscale.com/admin/dns) by clicking "Enable HTTPS..." (required for TLS certificate generation).
 
-## Components of the Repository
-
-- **`install.yaml`** - DDEV add-on installation manifest that copies necessary files and shows setup instructions
-- **`docker-compose.tailscale-router.yaml`** - Core Docker Compose configuration defining the `tailscale-router` service with Tailscale authentication and `socat` traffic forwarding
-- **`commands/host/tailscale`** - Custom DDEV host command providing access to Tailscale CLI with helpful shortcuts
-- **`tailscale-router/config/`** - JSON configuration files for Tailscale's serve command:
-  - `tailscale-private.json` - Private sharing configuration (default)
-  - `tailscale-public.json` - Public sharing configuration
-- **`tests/test.bats`** - Automated test script for verifying Tailscale integration
-- **`.github/workflows/tests.yml`** - GitHub Actions for automated testing on push and schedule
-- **`.github/ISSUE_TEMPLATE/` and `PULL_REQUEST_TEMPLATE.md`** - Templates for streamlined contributions
-
-## Getting Started
-
-### 1. Install the Add-on
+## Installation
 
 ```bash
-ddev add-on get atj4me/ddev-tailscale-router
-```
-
-### 2. Get a Tailscale Auth Key
-
-Get an auth key from the [Tailscale admin console](https://tailscale.com/kb/1085/auth-keys) (ephemeral, reusable keys are recommended).
-
-### 3. Configure the Auth Key
-
-```bash
+# get the auth key from prerequisites
 ddev dotenv set .ddev/.env.tailscale-router --ts-authkey=tskey-auth-your-key-here
-```
 
-### 4. Restart DDEV
-
-```bash
+ddev add-on get atj4me/ddev-tailscale-router
 ddev restart
+
+# Launch your project's Tailscale URL in browser
+ddev tailscale launch
+# Or get your project's Tailscale URL
+ddev tailscale url
 ```
 
-### 5. Access Your Site
+Your project's permanent Tailscale URL will look like: `https://<project-name>.<your-tailnet>.ts.net`. Also, it can be found in your [Tailscale admin console](https://login.tailscale.com/admin/machines).
 
-After restarting, you can access your site in several ways:
-
-- **Launch in browser**: `ddev tailscale launch`
-- **Get the URL**: `ddev tailscale url` 
-- **Find in admin console**: [Tailscale admin console](https://login.tailscale.com/admin/machines)
-
-Your project's permanent Tailscale URL will look like: `https://<project-name>.<your-tailnet>.ts.net`
-
-### 6. Configure Privacy (Optional)
+### Configure Privacy (Optional)
 
 By default, your project is only accessible to devices on your Tailscale network (private mode). You can make it publicly accessible:
 
@@ -98,32 +72,41 @@ ddev dotenv set .ddev/.env.tailscale-router --ts-privacy=private
 ddev restart
 ```
 
-## Commands
-
-The add-on provides two types of commands:
-
-### Container Commands
+## Usage
 
 Access all [Tailscale CLI](https://tailscale.com/kb/1080/cli) commands plus helpful shortcuts:
 
-```bash
-# Standard Tailscale commands
-ddev tailscale status
-ddev tailscale ping <device>
+| Command | Description |
+| ------- | ----------- |
+| `ddev tailscale launch` | Launch your project's Tailscale URL in browser |
+| `ddev tailscale <anything>` | Run any Tailscale CLI command |
+| `ddev tailscale status` | Show Tailscale status |
+| `ddev tailscale ping <device>` | Ping a Tailscale device |
+| `ddev tailscale stat` | Show status with self and active peers only |
+| `ddev tailscale proxy` | Show funnel status |
+| `ddev tailscale url` | Get your project's Tailscale URL |
 
-# Helpful shortcuts
-ddev tailscale stat      # Show status with self and active peers only
-ddev tailscale proxy     # Show funnel status
-ddev tailscale url       # Get your project's Tailscale URL
-```
+## Advanced Customization
 
-### Host Commands
+All customization options (use with caution):
 
-Launch your Tailscale URL directly in your browser:
+| Variable | Flag | Default |
+| -------- | ---- | ------- |
+| `TS_DOCKER_IMAGE` | `--ts-docker-image` | `tailscale/tailscale:latest` |
+| `TS_AUTHKEY` | `--ts-authkey` | (none, required) |
+| `TS_PRIVACY` | `--ts-privacy` | `private` (`private`/`public`) |
 
-```bash
-ddev tailscale launch    # Launch your project's Tailscale URL in browser
-``` 
+## Components of the Repository
+
+- **`install.yaml`** - DDEV add-on installation manifest that copies necessary files and shows setup instructions
+- **`docker-compose.tailscale-router.yaml`** - Core Docker Compose configuration defining the `tailscale-router` service with Tailscale authentication and `socat` traffic forwarding
+- **`commands/host/tailscale`** - Custom DDEV host command providing access to Tailscale CLI with helpful shortcuts
+- **`tailscale-router/config/`** - JSON configuration files for Tailscale's serve command:
+  - `tailscale-private.json` - Private sharing configuration (default)
+  - `tailscale-public.json` - Public sharing configuration
+- **`tests/test.bats`** - Automated test script for verifying Tailscale integration
+- **`.github/workflows/tests.yml`** - GitHub Actions for automated testing on push and schedule
+- **`.github/ISSUE_TEMPLATE/` and `PULL_REQUEST_TEMPLATE.md`** - Templates for streamlined contributions
 
 ## Testing
 
@@ -152,6 +135,6 @@ This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE
 
 ---
 
-Maintained by `@atj4me` 🚀  
+Maintained by [@atj4me](https://github.com/atj4me) 🚀
 
 Let me know if you want any tweaks! 🎯

--- a/README.md
+++ b/README.md
@@ -38,15 +38,24 @@ This add-on is particularly useful for:
 Before installing the add-on:
 
 1. [Install Tailscale](https://tailscale.com/download) on any two devices (computer, phone, or tablet). This is required to generate the auth key.
-2. [Generate an auth key](https://tailscale.com/kb/1085/auth-keys) in your [Keys settings](https://login.tailscale.com/admin/settings/keys) (ephemeral, reusable keys are recommended).
-3. [Enable HTTPS](https://tailscale.com/kb/1153/enabling-https) in your [DNS settings](https://login.tailscale.com/admin/dns) by clicking "Enable HTTPS..." (required for TLS certificate generation).
+2. [Enable HTTPS](https://tailscale.com/kb/1153/enabling-https) in your [DNS settings](https://login.tailscale.com/admin/dns) by clicking "Enable HTTPS..." (required for TLS certificate generation).
+3. [Generate an auth key](https://tailscale.com/kb/1085/auth-keys) in your [Keys settings](https://login.tailscale.com/admin/settings/keys) (ephemeral, reusable keys are recommended).
+
+    Get the auth key and add it to your environment by updating `~/.bashrc`, `~/.zshrc`, or another relevant shell configuration file with this command:
+
+    ```bash
+    echo 'export TS_AUTHKEY=tskey-auth-your-key-here' >> ~/.bashrc
+    ```
+
+    Alternatively, you can set it per project (**NOT RECOMMENDED**, because `.ddev/.env.tailscale-router` is not intended to store secrets) using:
+
+    ```bash
+    ddev dotenv set .ddev/.env.tailscale-router --ts-authkey=tskey-auth-your-key-here
+    ```
 
 ## Installation
 
 ```bash
-# get the auth key from prerequisites
-ddev dotenv set .ddev/.env.tailscale-router --ts-authkey=tskey-auth-your-key-here
-
 ddev add-on get atj4me/ddev-tailscale-router
 ddev restart
 
@@ -78,22 +87,30 @@ Access all [Tailscale CLI](https://tailscale.com/kb/1080/cli) commands plus help
 
 | Command | Description |
 | ------- | ----------- |
-| `ddev tailscale launch` | Launch your project's Tailscale URL in browser |
 | `ddev tailscale <anything>` | Run any Tailscale CLI command |
+| `ddev tailscale launch` | Launch your project's Tailscale URL in browser |
 | `ddev tailscale status` | Show Tailscale status |
 | `ddev tailscale ping <device>` | Ping a Tailscale device |
 | `ddev tailscale stat` | Show status with self and active peers only |
 | `ddev tailscale proxy` | Show funnel status |
 | `ddev tailscale url` | Get your project's Tailscale URL |
+| `ddev logs -s tailscale-router` | Show logs for the Tailscale router service |
 
 ## Advanced Customization
+
+To change the used Docker image:
+
+```bash
+ddev dotenv set .ddev/.env.tailscale-router --ts-docker-image=tailscale/tailscale:latest
+ddev restart
+```
 
 All customization options (use with caution):
 
 | Variable | Flag | Default |
 | -------- | ---- | ------- |
 | `TS_DOCKER_IMAGE` | `--ts-docker-image` | `tailscale/tailscale:latest` |
-| `TS_AUTHKEY` | `--ts-authkey` | (none, required) |
+| `TS_AUTHKEY` | `--ts-authkey` | (none, required, not recommended to set in `.ddev/.env.tailscale-router`) |
 | `TS_PRIVACY` | `--ts-privacy` | `private` (`private`/`public`) |
 
 ## Components of the Repository

--- a/docker-compose.tailscale-router.yaml
+++ b/docker-compose.tailscale-router.yaml
@@ -24,7 +24,7 @@ services:
       - ./tailscale-router/config:/config:ro
       - .:/mnt/ddev_config
       - ddev-global-cache:/mnt/ddev-global-cache
-    restart: unless-stopped
+    restart: "no"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}

--- a/docker-compose.tailscale-router.yaml
+++ b/docker-compose.tailscale-router.yaml
@@ -1,21 +1,24 @@
 #ddev-generated
 services:
   tailscale-router:
+    image: ${TS_DOCKER_IMAGE:-tailscale/tailscale:latest}-${DDEV_SITENAME}-built
     build:
-      context: .
       dockerfile_inline: |
-        FROM tailscale/tailscale:latest
+        ARG TS_DOCKER_IMAGE=scratch
+        FROM $$TS_DOCKER_IMAGE
         RUN apk add --no-cache socat
+      args:
+        TS_DOCKER_IMAGE: ${TS_DOCKER_IMAGE:-tailscale/tailscale:latest}
     hostname: ${DDEV_SITENAME}
     container_name: ddev-${DDEV_SITENAME}-tailscale-router
     environment:
-      TS_AUTHKEY: ${TS_AUTHKEY}
+      TS_AUTHKEY: ${TS_AUTHKEY:-}
       TS_HOSTNAME: ${DDEV_SITENAME}
       TS_EXTRA_ARGS: --accept-routes --ssh
       TS_STATE_DIR: /var/lib/tailscale
       TS_USERSPACE: "true"
       TS_PRIVACY: ${TS_PRIVACY:-private}
-      TS_SERVE_CONFIG: /config/tailscale-${TS_PRIVACY}.json
+      TS_SERVE_CONFIG: /config/tailscale-${TS_PRIVACY:-private}.json
     volumes:
       - tailscale-router-state:/var/lib/tailscale
       - ./tailscale-router/config:/config:ro

--- a/install.yaml
+++ b/install.yaml
@@ -14,7 +14,7 @@ post_install_actions:
     echo "🚀 ddev-tailscale-router installed successfully!"
     echo "Next steps:"
     echo "1. Get your Tailscale auth key from https://tailscale.com/kb/1085/auth-keys"
-    echo "2. Set it using: 'ddev dotenv set .ddev/.env.tailscale-router --ts-authkey=tskey-auth-xxxx'"
+    echo "2. Set it in your environment using: 'echo \"export TS_AUTHKEY=tskey-auth-your-key-here\" >> ~/.bashrc'"
     echo "3. Optional: Set privacy to public with: 'ddev dotenv set .ddev/.env.tailscale-router --ts-privacy=public'"
     echo "4. Run: 'ddev restart'"
     echo "For more info: https://github.com/atj4me/ddev-tailscale-router"

--- a/install.yaml
+++ b/install.yaml
@@ -10,16 +10,11 @@ ddev_version_constraint: '>= v1.24.3'
 
 post_install_actions:
   - |
-    #ddev-description:Setup Tailscale router environment
-    if ! ddev dotenv get .ddev/.env.tailscale-router --ts-privacy >/dev/null 2>&1; then
-      ddev dotenv set .ddev/.env.tailscale-router --ts-privacy=private
-    fi
-  - |
     #ddev-description:Setup instructions for Tailscale router
     echo "🚀 ddev-tailscale-router installed successfully!"
     echo "Next steps:"
     echo "1. Get your Tailscale auth key from https://tailscale.com/kb/1085/auth-keys"
-    echo "2. Set it using: ddev dotenv set .ddev/.env.tailscale-router --ts-authkey=tskey-auth-xxxx"
-    echo "3. Optional: Set privacy to public with: ddev dotenv set .ddev/.env.tailscale-router --ts-privacy=public"
-    echo "4. Run: ddev restart"
+    echo "2. Set it using: 'ddev dotenv set .ddev/.env.tailscale-router --ts-authkey=tskey-auth-xxxx'"
+    echo "3. Optional: Set privacy to public with: 'ddev dotenv set .ddev/.env.tailscale-router --ts-privacy=public'"
+    echo "4. Run: 'ddev restart'"
     echo "For more info: https://github.com/atj4me/ddev-tailscale-router"

--- a/tailscale-router/config/tailscale-private.json
+++ b/tailscale-router/config/tailscale-private.json
@@ -1,20 +1,20 @@
 {
-    "#ddev-generated":true,
-    "TCP": {
-      "443": {
-        "HTTPS": true
-      }
-    },
-    "Web": {
-      "${TS_CERT_DOMAIN}:443": {
-        "Handlers": {
-          "/": {
-            "Proxy": "http://127.0.0.1:8080"
-          }
+  "#ddev-generated":true,
+  "TCP": {
+    "443": {
+      "HTTPS": true
+    }
+  },
+  "Web": {
+    "${TS_CERT_DOMAIN}:443": {
+      "Handlers": {
+        "/": {
+          "Proxy": "http://127.0.0.1:8080"
         }
       }
-    },
-    "AllowFunnel": {
-      "${TS_CERT_DOMAIN}:443": false
     }
+  },
+  "AllowFunnel": {
+    "${TS_CERT_DOMAIN}:443": false
   }
+}

--- a/tailscale-router/config/tailscale-public.json
+++ b/tailscale-router/config/tailscale-public.json
@@ -1,20 +1,20 @@
 {
-    "#ddev-generated":true,
-    "TCP": {
-      "443": {
-        "HTTPS": true
-      }
-    },
-    "Web": {
-      "${TS_CERT_DOMAIN}:443": {
-        "Handlers": {
-          "/": {
-            "Proxy": "http://127.0.0.1:8080"
-          }
+  "#ddev-generated":true,
+  "TCP": {
+    "443": {
+      "HTTPS": true
+    }
+  },
+  "Web": {
+    "${TS_CERT_DOMAIN}:443": {
+      "Handlers": {
+        "/": {
+          "Proxy": "http://127.0.0.1:8080"
         }
       }
-    },
-    "AllowFunnel": {
-      "${TS_CERT_DOMAIN}:443": true
     }
+  },
+  "AllowFunnel": {
+    "${TS_CERT_DOMAIN}:443": true
   }
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -38,7 +38,7 @@ setup() {
 
 health_checks() {
   # Check if the Tailscale service is running inside DDEV
-  run ddev describe -j 
+  run ddev describe -j
   assert_success
 
   # Verify tailscale-router service exists in describe output
@@ -86,7 +86,7 @@ teardown() {
   assert_success
   run ddev restart -y
   assert_success
-  
+
   # Test tailscale command exists (without --help which may not work)
   run ddev tailscale status
   # Command should execute (may show error but shouldn't crash)
@@ -98,7 +98,7 @@ teardown() {
   assert_success
   run ddev restart -y
   assert_success
-  
+
   # Check if tailscale-router container exists
   run docker ps -a --filter "name=ddev-${PROJNAME}-tailscale-router" --format "{{.Names}}"
   assert_success
@@ -109,7 +109,7 @@ teardown() {
   set -eu -o pipefail
   run ddev add-on get "${DIR}"
   assert_success
-  
+
   # Check if config files exist
   assert_file_exists ".ddev/tailscale-router/config/tailscale-private.json"
   assert_file_exists ".ddev/tailscale-router/config/tailscale-public.json"
@@ -123,11 +123,11 @@ teardown() {
   assert_success
   run ddev restart -y
   assert_success
-  
+
   # Test stat command (should not fail even without auth)
   run ddev tailscale stat
   # Command should execute (may show not logged in, but shouldn't crash)
-  
+
   # Test proxy command
   run ddev tailscale proxy
   # Command should execute
@@ -137,15 +137,15 @@ teardown() {
   set -eu -o pipefail
   run ddev add-on get "${DIR}"
   assert_success
-  
+
   # Check docker-compose file contains required elements
   run grep -q "tailscale-router:" ".ddev/docker-compose.tailscale-router.yaml"
   assert_success
-  
+
   run grep -q "tailscale-router-state:" ".ddev/docker-compose.tailscale-router.yaml"
   assert_success
-  
-  run grep -q "FROM tailscale/tailscale:latest" ".ddev/docker-compose.tailscale-router.yaml"
+
+  run grep -q "image: \${TS_DOCKER_IMAGE:-tailscale/tailscale:latest}-\${DDEV_SITENAME}-built" ".ddev/docker-compose.tailscale-router.yaml"
   assert_success
 }
 
@@ -153,13 +153,13 @@ teardown() {
   set -eu -o pipefail
   run ddev add-on get "${DIR}"
   assert_success
-  
+
   # Check private config
   run grep -q '"AllowFunnel"' ".ddev/tailscale-router/config/tailscale-private.json"
   assert_success
   run grep -q 'false' ".ddev/tailscale-router/config/tailscale-private.json"
   assert_success
-  
+
   # Check public config
   run grep -q '"AllowFunnel"' ".ddev/tailscale-router/config/tailscale-public.json"
   assert_success


### PR DESCRIPTION
## The Issue

This is a follow up for:

- https://github.com/ddev/ddev.com/pull/423

## How This PR Solves The Issue

- I ran the [Update Checker](https://github.com/ddev/ddev-addon-template#update-checker).
- `docker-compose.yaml` didn't have some defaults set
- README.md didn't use the same sections as in official add-ons.
- Do not set `TS_AUTHKEY` in the `.ddev/.env.tailscale-router` file - it's purpose to be committed, but you don't want to commit secrets.
- Do not restart it all the time on wrong api key.

## Manual Testing Instructions

Review https://github.com/stasadev/ddev-tailscale-router/blob/20250906_stasadev_fixes/README.md

```bash
ddev add-on get https://github.com/atj4me/ddev-tailscale-router/tarball/refs/pull/15/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
