### PR TITLE
Adding the TS Funnel ACL section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ Before installing the add-on:
     ddev dotenv set .ddev/.env.tailscale-router --ts-authkey=tskey-auth-your-key-here
     ```
 
+4. **For public access**: Configure your [Access Control List (ACL)](https://tailscale.com/kb/1223/funnel#funnel-node-attribute) to enable Funnel. Add the `funnel` node attribute to your ACL policy in the [Tailscale admin console](https://login.tailscale.com/admin/acls):
+
+    ```json
+    {
+      "nodeAttrs": [
+        {
+          "target": ["*"],
+          "attr": ["funnel"]
+        }
+      ]
+    }
+    ```
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## The Issue

- Improves documentation clarity for public access setup

The Prerequisites section was missing crucial information about ACL configuration required for Tailscale Funnel to work in public mode. Without this configuration, users would be unable to access their projects publicly even when setting `--ts-privacy=public`.

## How This PR Solves The Issue

Added step 4 to the Prerequisites section that explains:
- ACL configuration is required for public access via Tailscale Funnel
- Provides the exact JSON configuration needed with the `funnel` node attribute
- Links to official Tailscale documentation for reference

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/atj4me/ddev-tailscale-router/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
