### PR TITLE
name:ddev-tailscale-router -> tailscale-router

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,4 @@
-name: ddev-tailscale-router
+name: tailscale-router
 
 project_files:
   - tailscale-router/config/tailscale-private.json


### PR DESCRIPTION
I've been suggesting that people use the simple name instead of the full name because it's shorter. It doesn't matter for most things, and you've used the regular "tailscale-router" everywhere else.

