### PR TITLE
Fix/socket dir permissions

### DIFF
--- a/config.tailscale-router.yaml
+++ b/config.tailscale-router.yaml
@@ -2,7 +2,7 @@
 # This configuration adds Tailscale routing capabilities to the web container.
 web_extra_daemons:
   - name: tailscale-service
-    command: tailscaled --statedir=${TS_STATE_DIR:-/var/lib/tailscale} --tun=userspace-networking
+    command: "/usr/local/bin/start-tailscaled.sh"
     directory: /usr/sbin
 
 hooks:

--- a/config.tailscale-router.yaml
+++ b/config.tailscale-router.yaml
@@ -1,4 +1,3 @@
-#ddev-generated
 # This configuration adds Tailscale routing capabilities to the web container.
 web_extra_daemons:
   - name: tailscale-service

--- a/web-build/Dockerfile.tailscale-router
+++ b/web-build/Dockerfile.tailscale-router
@@ -1,4 +1,3 @@
-#ddev-generated
 RUN curl -fsSL https://tailscale.com/install.sh | sh
 
 ARG username

--- a/web-build/Dockerfile.tailscale-router
+++ b/web-build/Dockerfile.tailscale-router
@@ -3,3 +3,6 @@ RUN curl -fsSL https://tailscale.com/install.sh | sh
 
 ARG username
 RUN mkdir -p /var/lib/tailscale && chown -R ${username}:${username} /var/lib/tailscale
+RUN mkdir -p /var/run/tailscale && chown -R ${username}:${username} /var/run/tailscale
+COPY start-tailscaled.sh /usr/local/bin/start-tailscaled.sh
+RUN chmod +x /usr/local/bin/start-tailscaled.sh

--- a/web-build/start-tailscaled.sh
+++ b/web-build/start-tailscaled.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec tailscaled --statedir="${TS_STATE_DIR:-/var/lib/tailscale}" --tun=userspace-networking


### PR DESCRIPTION
The Dockerfile creates `/var/lib/tailscale` (the state dir) but never
creates `/var/run/tailscale` (the socket dir), so the daemon cannot start.

## Fix

- Create `/var/run/tailscale` with the correct ownership at build time in
  `Dockerfile.tailscale-router`, mirroring how `/var/lib/tailscale` is
  already handled.
- Move the daemon startup into a small entrypoint script
  (`web-build/start-tailscaled.sh`) instead of an inline `command:`, and
  point `config.tailscale-router.yaml` at it. This avoids fragile quoting
  across the DDEV → supervisor → shell layers and is the conventional place
  for pre-start setup.

## Testing

- Reproduced the crash loop on a clean DDEV project (DDEV v1.25.3,
  add-on v3.0.0, PHP 8.5, MySQL 8.4) on Ubuntu.
- After the fix, `tailscale-service` reaches `RUNNING`, `ddev tailscale
  launch` authenticates successfully, and the project is reachable at
  `https://<project>.<tailnet>.ts.net` from other tailnet devices.